### PR TITLE
Use Types::Standard for attribute checking

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ skip = ^(?:strict|warnings|utf8)$  ; Those are core modules.
 skip = ^Sereal(?:::(?:Decoder|Encoder))?$
 skip = ^strictures$
 skip = ^t::TestApp::RedisMock$
+skip = ^Types::Standard$           ; Part of Type::Tiny
 [Prereqs]
 strictures = 0
 [Prereqs / RuntimeRecommends]

--- a/lib/Dancer2/Session/Redis.pm
+++ b/lib/Dancer2/Session/Redis.pm
@@ -8,12 +8,12 @@ BEGIN {
 }
 
 use Carp qw( carp croak );
-use Dancer2::Core::Types qw( Undef AnyOf InstanceOf );
 use Moo;
 use Redis;
 use Safe::Isa;
 use Try::Tiny;
 use Type::Tiny;
+use Types::Standard qw( Maybe InstanceOf );
 
 with 'Dancer2::Core::Role::SessionFactory';
 
@@ -79,7 +79,7 @@ has redis_test_mock     => ( is => 'ro', default => sub { $ENV{DANCER_SESSION_RE
 
 has _serialization => (
   is      => 'lazy',
-  isa     => AnyOf [ Undef, $TYPE_SERIALIZATIONOBJECT ],
+  isa     => Maybe [ $TYPE_SERIALIZATIONOBJECT ],
   builder => sub {
     my ($dsl1) = @_;
     my $serialization;
@@ -105,7 +105,7 @@ has _serialization => (
 
 has _redis => (
   is      => 'lazy',
-  isa     => AnyOf [ InstanceOf ['Redis'], InstanceOf ['t::TestApp::RedisMock'] ],
+  isa     => InstanceOf [ 'Redis', 't::TestApp::RedisMock' ],
   builder => sub {
     my ($dsl2) = @_;
 


### PR DESCRIPTION
Same issue as with Dancer2::Plugin::Redis. The most recent version of
Dancer2 changed Dancer2::Types::Core from MooX::Types::MooseLike::Base
to Types::Standard. Since we already depend on Type::Tiny, which
includes Types::Standard, I've changed the attribute checking to use
Types::Standard.

(See burnersk/Dancer2-Plugin-Redis#9)