### PR TITLE
refactor unit tests

### DIFF
--- a/lib/Dancer2/Session/Redis.pm
+++ b/lib/Dancer2/Session/Redis.pm
@@ -106,16 +106,11 @@ sub _build__serialization {
 
 has _redis => (
   is      => 'lazy',
-  isa     => InstanceOf ['Redis'] | InstanceOf ['t::TestApp::RedisMock'],
+  isa     => InstanceOf ['Redis'],
 );
 
 sub _build__redis {
     my ($dsl2) = @_;
-
-    if ( $dsl2->redis_test_mock ) {
-      require t::TestApp::RedisMock;
-      return t::TestApp::RedisMock->new;
-    }
 
     # Build Redis->new settings.
     my %opts = (

--- a/lib/Dancer2/Session/Redis.pm
+++ b/lib/Dancer2/Session/Redis.pm
@@ -75,7 +75,6 @@ has redis_debug         => ( is => 'ro' );
 has redis_name          => ( is => 'ro' );
 has redis_key           => ( is => 'ro', default => 'session:%s' );
 has redis_serialization => ( is => 'ro' );
-has redis_test_mock     => ( is => 'ro', default => sub { $ENV{DANCER_SESSION_REDIS_TEST_MOCK} || 0 } );
 
 has _serialization => (
   is      => 'lazy',

--- a/t/001-use.t
+++ b/t/001-use.t
@@ -7,7 +7,10 @@ use lib 't/lib';
 
 use Util;
 
-BEGIN { Util::setenv }
+BEGIN {
+  Util::setenv;
+  Util::mock_redis;
+}
 
 use TestApp::Simple;
 

--- a/t/001-use.t
+++ b/t/001-use.t
@@ -3,22 +3,23 @@ use Test::More tests => 1 + 2;
 use Test::NoWarnings;
 use Plack::Test;
 use HTTP::Request::Common;
+use lib 't/lib';
 
-use t::Util;
+use Util;
 
-BEGIN { t::Util::setenv }
+BEGIN { Util::setenv }
 
-use t::TestApp::Simple;
+use TestApp::Simple;
 
-BEGIN { t::Util::setconf( \&t::TestApp::Simple::set ) }
+BEGIN { Util::setconf( \&TestApp::Simple::set ) }
 
 ############################################################################
 
-my $app = t::TestApp::Simple->psgi_app;
+my $app = TestApp::Simple->psgi_app;
 ok( $app, 'Got App' );
 
 ############################################################################
 
-t::Util::psgi_request_ok( $app, GET => q{/}, qr/^Hello World$/ );
+Util::psgi_request_ok( $app, GET => q{/}, qr/^Hello World$/ );
 
 ############################################################################

--- a/t/002-get-set.t
+++ b/t/002-get-set.t
@@ -3,26 +3,27 @@ use Test::More tests => 1 + 6;
 use Test::NoWarnings;
 use Plack::Test;
 use HTTP::Request::Common;
+use lib 't/lib';
 
-use t::Util;
+use Util;
 
-BEGIN { t::Util::setenv }
+BEGIN { Util::setenv }
 
-use t::TestApp::Simple;
+use TestApp::Simple;
 
-BEGIN { t::Util::setconf( \&t::TestApp::Simple::set ) }
+BEGIN { Util::setconf( \&TestApp::Simple::set ) }
 
 ############################################################################
 
-my $app = t::TestApp::Simple->psgi_app;
+my $app = TestApp::Simple->psgi_app;
 ok( $app, 'Got App' );
 
 ############################################################################
 
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: $/ );
-t::Util::psgi_request_ok( $app, GET => q{/set?key=foo&value=bar}, qr/^set foo: bar$/ );
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
-t::Util::psgi_change_session_id( $app );
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: $/ );
+Util::psgi_request_ok( $app, GET => q{/set?key=foo&value=bar}, qr/^set foo: bar$/ );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
+Util::psgi_change_session_id( $app );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
 
 ############################################################################

--- a/t/002-get-set.t
+++ b/t/002-get-set.t
@@ -7,7 +7,10 @@ use lib 't/lib';
 
 use Util;
 
-BEGIN { Util::setenv }
+BEGIN {
+  Util::setenv;
+  Util::mock_redis;
+}
 
 use TestApp::Simple;
 

--- a/t/003-get-set-redis.t
+++ b/t/003-get-set-redis.t
@@ -12,7 +12,6 @@ BEGIN {
     eval 'use Sereal::Encoder;1'
         or plan skip_all => "Sereal::Encoder needed to run these tests";
     Util::setenv;
-    $ENV{DANCER_SESSION_REDIS_TEST_MOCK} = 0;
 }
 
 use TestApp::Simple;

--- a/t/003-get-set-redis.t
+++ b/t/003-get-set-redis.t
@@ -2,37 +2,38 @@ use strictures 1;
 use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
+use lib 't/lib';
 
-use t::Util;
+use Util;
 
 BEGIN {
     eval 'use Sereal::Decoder;1'
         or plan skip_all => "Sereal::Decoder needed to run these tests";
     eval 'use Sereal::Encoder;1'
         or plan skip_all => "Sereal::Encoder needed to run these tests";
-    t::Util::setenv;
+    Util::setenv;
     $ENV{DANCER_SESSION_REDIS_TEST_MOCK} = 0;
 }
 
-use t::TestApp::Simple;
+use TestApp::Simple;
 
 BEGIN {
-  t::Util::setconf( \&t::TestApp::Simple::set )
+  Util::setconf( \&TestApp::Simple::set )
     or plan( skip_all => "Redis server not found so tests cannot be run" );
 }
 
 ############################################################################
 
-my $app = t::TestApp::Simple->psgi_app;
+my $app = TestApp::Simple->psgi_app;
 ok( $app, 'Got App' );
 
 ############################################################################
 
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: $/ );
-t::Util::psgi_request_ok( $app, GET => q{/set?key=foo&value=bar}, qr/^set foo: bar$/ );
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
-t::Util::psgi_change_session_id( $app );
-t::Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: $/ );
+Util::psgi_request_ok( $app, GET => q{/set?key=foo&value=bar}, qr/^set foo: bar$/ );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
+Util::psgi_change_session_id( $app );
+Util::psgi_request_ok( $app, GET => q{/get?key=foo},           qr/^get foo: bar$/ );
 
 ############################################################################
 done_testing;

--- a/t/lib/TestApp/RedisMock.pm
+++ b/t/lib/TestApp/RedisMock.pm
@@ -1,10 +1,11 @@
-package t::TestApp::RedisMock;
+package TestApp::RedisMock;
 use strictures 1;
 # ABSTRACT: Redis mock for unit tests.
 # COPYRIGHT
 
 BEGIN {
   our $VERSION = '0.002';  # fixed version - NOT handled via DZP::OurPkgVersion.
+  our @ISA = 'Redis';
 }
 
 use Moo;
@@ -17,6 +18,10 @@ has _storage => (
   isa     => HashRef,
   default => sub { {} },
 );
+
+############################################################################
+
+sub connect { 1; }
 
 ############################################################################
 

--- a/t/lib/TestApp/Simple.pm
+++ b/t/lib/TestApp/Simple.pm
@@ -1,4 +1,4 @@
-package t::TestApp::Simple;
+package TestApp::Simple;
 use strictures 1;
 # ABSTRACT: Test application for unit tests.
 # COPYRIGHT

--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -1,4 +1,4 @@
-package t::Util;
+package Util;
 use strictures 1;
 
 use Test::More;
@@ -6,19 +6,24 @@ use Plack::Test;
 use HTTP::Request::Common;
 use HTTP::Cookies;
 use Redis;
+require Dancer2::Session::Redis;
+
+{
+  no warnings 'redefine';
+
+  # mock the Redis constructor in our session
+  *Dancer2::Session::Redis::_build__redis = sub {
+    require TestApp::RedisMock;
+    return TestApp::RedisMock->new;
+  };
+}
 
 my $jar = HTTP::Cookies->new;
-
-############################################################################
-# Setup environment for Delti::WheelShop testing environment.
 
 sub setenv {
   $ENV{PLACK_ENV} = $ENV{DANCER_ENVIRONMENT} = 'testing';
   $ENV{DANCER_SESSION_REDIS_TEST_MOCK} = 1;
 }
-
-############################################################################
-# Setup environment for Delti::WheelShop testing environment.
 
 sub setconf {
   my ($set) = @_;
@@ -83,6 +88,7 @@ sub psgi_request_ok {
   test_psgi( $app, $client );
   return;
 }
+
 sub psgi_change_session_id {
   my $app = shift;
   my $client = sub {


### PR DESCRIPTION
Moved the test libs to t/libs and got rid of the t:: namespace. Extended the TestApp::RedisMock to inherit from Redis and turned off the real connection. Moved the mocking into t/Util.pm. This way we can completely eliminate the testing-related code in the actual production code.